### PR TITLE
Fix/react helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9316,25 +9316,25 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.3.1.tgz",
-      "integrity": "sha512-DZ/IWs+zlGL8N3JAcewPJJUPkl1st6/hIWQ3YphKoTK64DUIoMd2wWSJCrC6LiurS7knGHa4pdGyc5clwV1EKA==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.3.10.tgz",
+      "integrity": "sha512-AcXYwmS3r298JWs6iQ3OLNxIe8L8i5a2iSdLr/SDMpHqumYm7q/vB9kCX0et5wM7DIuZ7aPXDrdi5yDCAvU5lg==",
       "requires": {
-        "@babel/runtime": "^7.9.6"
+        "@babel/runtime": "^7.10.3"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7651,11 +7651,6 @@
         "pify": "^2.2.0"
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -16964,19 +16959,19 @@
       "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
     },
     "react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-helmet": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz",
-      "integrity": "sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
       "requires": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-fast-compare": "^2.0.2",
-        "react-side-effect": "^1.1.0"
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
       }
     },
     "react-hot-loader": {
@@ -17045,13 +17040,9 @@
       "integrity": "sha512-u5l7fhAJXecWUJzVxzMRU2Zvw8m4QmDNHlTrT5uo3KBlYBhmChd7syAakBoay1yIiVhx/8Fi7a6v6kQZfsw81Q=="
     },
     "react-side-effect": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
-      "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
-      "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "react-slick": {
       "version": "0.25.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-helmet": "^5.2.1",
+    "react-helmet": "^6.1.0",
     "react-id-swiper": "^3.0.0",
     "react-messenger-customer-chat": "^0.7.2",
     "react-slick": "^0.25.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gatsby-plugin-manifest": "^2.4.2",
     "gatsby-plugin-offline": "^3.2.1",
     "gatsby-plugin-optimize-svgs": "^1.0.4",
-    "gatsby-plugin-react-helmet": "^3.3.1",
+    "gatsby-plugin-react-helmet": "^3.3.10",
     "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-robots-txt": "^1.5.1",
     "gatsby-plugin-sass": "^2.3.1",

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 
 import { useSiteMetadata } from '@hooks/queries';
 
@@ -54,13 +54,6 @@ const Head = ({ children, title, description }) => {
       },
     ],
   };
-
-  // eslint-disable-next-line no-console
-  console.log(`
-    Warning "componentWillMount has been renamed" maked by Head Component.
-    Helmet issue: https://github.com/nfl/react-helmet/issues/499.
-    Solution: update package to 6.0.0 version when it will be available. 
-  `);
 
   return (
     <Helmet>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,5 @@
 import React, { useContext, useRef } from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 


### PR DESCRIPTION
`react-helmet` upgraded to 6.1.0 according to [Release Note v6.0.0](https://github.com/nfl/react-helmet/releases/tag/6.0.0)
> Bundle with Rollup instead of Webpack - As a result, the default export was removed and Helmet must now be imported as a named component - import {Helmet} from "react-helmet"

`gatsby-plugin-react-helmet` supports `react-helmet` as stated in `package.json` of the [package.json](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-react-helmet/package.json)
```js
"peerDependencies": {
    "gatsby": "^2.0.0",
    "react-helmet": "^5.1.3 || ^6.0.0"
  },
```