### PR TITLE
deleted console.log from use-breakpoins-width package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20695,9 +20695,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "use-breakpoints-width": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/use-breakpoints-width/-/use-breakpoints-width-1.0.7.tgz",
-      "integrity": "sha512-dw7MPOQDS44V2FHqfGA/IGJC8PS8zpRutPPQVxjDmNV8s7e4X/EvR03Nk96pu5HfXiiDcQxpW8v89CK9nLvztw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/use-breakpoints-width/-/use-breakpoints-width-1.0.8.tgz",
+      "integrity": "sha512-8olgo6Aj4s4EWXaMTkQFbpizVafn5hYfO/nTQ5vcZi+hSoShMhe2XdgeVMwwuxjL/mkM105qYrJagOQDGLIVBg=="
     },
     "utif": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-tabs": "^3.1.0",
     "slick-carousel": "^1.8.1",
     "swiper": "^5.3.8",
-    "use-breakpoints-width": "^1.0.7"
+    "use-breakpoints-width": "^1.0.8"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
Deleted console.log command from `use-breakpoins-width` package and upgraded to 1.0.8

