### PR TITLE
Feature/text animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17004,6 +17004,14 @@
         "object-assign": "^4.1.1"
       }
     },
+    "react-intersection-observer": {
+      "version": "8.27.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.27.1.tgz",
+      "integrity": "sha512-s70LKz+hm8wQY/4pvGVWs/gAfiLPlivyZiiUU1JdWDZj7vN8jbHYzJ8H1HWGvWpcudRg7g7kBWUUbcRjlloD0Q==",
+      "requires": {
+        "tiny-invariant": "^1.1.0"
+      }
+    },
     "react-is": {
       "version": "16.8.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
@@ -19896,6 +19904,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",
     "react-id-swiper": "^3.0.0",
+    "react-intersection-observer": "^8.27.1",
     "react-messenger-customer-chat": "^0.7.2",
     "react-slick": "^0.25.2",
     "react-spring": "^8.0.27",

--- a/src/scenes/Projects/components/List/components/ProjectScene/ProjectScene.js
+++ b/src/scenes/Projects/components/List/components/ProjectScene/ProjectScene.js
@@ -37,10 +37,10 @@ function debounce(func, wait = 5, immediate = false) {
 }
 
 const config = {
-  big: 180,
-  middle: 160,
-  small: 100,
-  base: 60,
+  big: 120,
+  middle: 106,
+  small: 66.6,
+  base: 40,
 };
 
 const ProjectScene = ({
@@ -98,7 +98,7 @@ const ProjectScene = ({
       ratio.current = getCoef(
         distanceToTop.current,
         startPosition.current,
-        0.35
+        0.4
       );
 
       setBaseMove(translate(config.base, ratio.current));

--- a/src/scenes/Projects/components/List/components/ProjectScene/ProjectScene.js
+++ b/src/scenes/Projects/components/List/components/ProjectScene/ProjectScene.js
@@ -22,10 +22,10 @@ function thresholdList(size = 10) {
 
 function debounce(func, wait = 5, immediate = false) {
   let timeout;
-  return function () {
+  return () => {
     const context = this;
     const args = arguments;
-    const later = function () {
+    const later = () => {
       timeout = null;
       if (!immediate) func.apply(context, args);
     };

--- a/src/scenes/Projects/components/List/components/ProjectScene/ProjectScene.js
+++ b/src/scenes/Projects/components/List/components/ProjectScene/ProjectScene.js
@@ -1,7 +1,32 @@
-import React, { Fragment } from 'react';
+import React, {
+  Fragment,
+  useRef,
+  useEffect,
+  useCallback,
+  useState,
+} from 'react';
+import { useInView } from 'react-intersection-observer';
 import Img from 'gatsby-image';
 import PropTypes from 'prop-types';
 import styles from './ProjectScene.module.scss';
+
+const settings = {
+  delay: '2s',
+  ease: 'cubic-bezier(0.16, 1, 0.3, 1)',
+};
+
+function thresholdList() {
+  let thresholds = [];
+  let numSteps = 20;
+
+  for (let i = 1.0; i <= numSteps; i++) {
+    let ratio = i / numSteps;
+    thresholds.push(ratio);
+  }
+
+  thresholds.push(0);
+  return thresholds;
+}
 
 const ProjectScene = ({
   link,
@@ -12,9 +37,105 @@ const ProjectScene = ({
   tags,
   title,
 }) => {
+  const elRef = useRef(null);
+  const distanceToTop = useRef(0);
+  const startPosition = useRef(0);
+
+  const [smallTranslate, setSmallTranslate] = useState();
+  const [middleTranslate, setMiddleTranslate] = useState();
+  const [bigTranslate, setBigTranslate] = useState();
+
+  useEffect(() => {
+    const style1 = {
+      transform: `translate3d(0, 80px, 0)`,
+      transition: `transform ${settings.delay} ${settings.ease}`,
+    };
+
+    const style2 = {
+      transform: `translate3d(0, 120px, 0)`,
+      transition: `transform ${settings.delay} ${settings.ease}`,
+    };
+
+    const style3 = {
+      transform: `translate3d(0, 160px, 0)`,
+      transition: `transform ${settings.delay} ${settings.ease}`,
+    };
+
+    if (startPositionFlag.current === false && inView) {
+      startPositionFlag.current = true;
+      startPosition.current = distanceToTop.current;
+    }
+
+    setSmallTranslate(style1);
+    setMiddleTranslate(style2);
+    setBigTranslate(style3);
+  }, []);
+
+  const startPositionFlag = useRef(false);
+
+  const coef = useRef(0);
+
+  const [blockRef, inView] = useInView({
+    threshold: thresholdList(),
+  });
+
+  const getCoef = (distToTop, startPos) => {
+    const result = distToTop / startPos;
+
+    if (!startPos || result < 0) {
+      return 0;
+    }
+
+    if (result > 1) {
+      return 1;
+    }
+
+    return result;
+  };
+
+  const squeezeText = useCallback(() => {
+    if (inView) {
+      distanceToTop.current = elRef.current.getBoundingClientRect().top;
+      coef.current = getCoef(distanceToTop.current, startPosition.current);
+
+      const style1 = {
+        transform: `translate3d(0, ${80 * coef.current}px, 0)`,
+        transition: `transform ${settings.delay} ${settings.ease}`,
+      };
+
+      const style2 = {
+        transform: `translate3d(0, ${120 * coef.current}px, 0)`,
+        transition: `transform ${settings.delay} ${settings.ease}`,
+      };
+
+      const style3 = {
+        transform: `translate3d(0, ${160 * coef.current}px, 0)`,
+        transition: `transform ${settings.delay} ${settings.ease}`,
+      };
+
+      if (startPositionFlag.current === false && inView) {
+        startPositionFlag.current = true;
+        startPosition.current = distanceToTop.current;
+      }
+
+      setSmallTranslate(style1);
+      setMiddleTranslate(style2);
+      setBigTranslate(style3);
+    }
+  }, [inView]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', squeezeText);
+    return () => window.removeEventListener('scroll', squeezeText);
+  }, [squeezeText]);
+
   return (
     <Fragment>
-      <div className={`${styles.preview} ${reversed ? styles.reversed : ''}`}>
+      <div
+        ref={blockRef}
+        style={smallTranslate}
+        className={`${styles.preview} ${reversed ? styles.reversed : ''}`}
+      >
         <a href={link} target="_blank" rel="noopener noreferrer">
           <Img fluid={preview.childImageSharp.fluid} draggable={false} />
           <span className={styles.hiddenTitle}>{title}</span>
@@ -23,18 +144,20 @@ const ProjectScene = ({
       <div
         className={`${styles.description} ${reversed ? styles.reversed : ''}`}
       >
-        <div className={styles.tags}>{tags}</div>
-        <div className={styles.title}>
+        <div ref={elRef} className={styles.tags} style={smallTranslate}>
+          {tags}
+        </div>
+        <div className={styles.title} style={middleTranslate}>
           <a href={link} target="_blank" rel="noopener noreferrer">
             {title}
           </a>
         </div>
-        <div className={styles.descriptionLink}>
+        <div className={styles.descriptionLink} style={bigTranslate}>
           <a href={link} target="_blank" rel="noopener noreferrer">
             {linkTitle}
           </a>
         </div>
-        <div className={styles.review}>
+        <div className={styles.review} style={bigTranslate}>
           <div className={styles.avatar}>
             <Img
               fluid={review.avatar.childImageSharp.fluid}


### PR DESCRIPTION
- replaced CSS ease by react-spring
- safari support: CSS ease `transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);` cause animation bugs
- optimization: animation is not happening when block out of viewport; debounced animation function
- animation disabled on a mobile screen < 768 px

`todo`
- remove debounce function and import it from `@helpers` after Alexey merges his branch `creative-gallery`

`default config`

```js
const config = {
   big: 180,
   middle: 160,
   small: 100,
   base: 60,
};
```

`candidate`

```js
const config = {
  big: 120,
  middle: 106,
  small: 66.6,
  base: 40,
};

```
